### PR TITLE
Upgrade to modern Flutter compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,28 +5,28 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:8.10.1'
     }
 }
 
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    namespace 'it.remedia.flutter_facebook_app_links'
+    compileSdkVersion 35
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 23
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
@@ -34,7 +34,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.facebook.android:facebook-core:12.3.0'
-        implementation 'com.facebook.android:facebook-applinks:12.3.0'
+        implementation 'com.facebook.android:facebook-core:16.3.0'
+        implementation 'com.facebook.android:facebook-applinks:16.3.0'
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,8 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    namespace 'it.remedia.flutter_facebook_app_links_example'
+    compileSdkVersion 35
 
     lintOptions {
         disable 'InvalidPackage'
@@ -34,8 +35,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "it.remedia.flutter_facebook_app_links_example"
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion 23
+        targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,18 +1,18 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:8.10.1'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,8 @@ description: Demonstrates how to use the flutter_facebook_app_links plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/ios/Classes/SwiftFlutterFacebookAppLinksPlugin.swift
+++ b/ios/Classes/SwiftFlutterFacebookAppLinksPlugin.swift
@@ -31,6 +31,9 @@ public class SwiftFlutterFacebookAppLinksPlugin: NSObject, FlutterPlugin {
     case "initFBLinks":
       print("FB APP LINK launched")
       handleFBAppLinks(call, result: result)
+    case "getDeepLinkUrl":
+      print("FB APP LINK getDeepLinkUrl called")
+      handleGetDeepLinkUrl(call, result: result)
     default:
       result(FlutterMethodNotImplemented)
     }
@@ -68,6 +71,25 @@ public class SwiftFlutterFacebookAppLinksPlugin: NSObject, FlutterPlugin {
       } else {
         // no deep link received
         result(nil)
+      }
+    }
+  }
+
+  private func handleGetDeepLinkUrl(_: FlutterMethodCall, result: @escaping FlutterResult) {
+    print("FB APP LINKS getDeepLinkUrl Starting ")
+
+    AppLinkUtility.fetchDeferredAppLink { url, error in
+      if let error = error {
+        print("Received error while fetching deferred app link %@", error)
+        result("")
+      }
+
+      if let url = url {
+        print("FB APP LINKS getDeepLinkUrl getting url: ", String(url.absoluteString))
+        result(url.absoluteString)
+      } else {
+        // no deep link received
+        result("")
       }
     }
   }

--- a/ios/flutter_facebook_app_links.podspec
+++ b/ios/flutter_facebook_app_links.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'FBSDKCoreKit', '~> 12.3.0'
-  s.swift_version = '4.0'
+  s.dependency 'FBSDKCoreKit', '~> 16.3.0'
+  s.swift_version = '5.0'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '12.0'
 end

--- a/lib/flutter_facebook_app_links.dart
+++ b/lib/flutter_facebook_app_links.dart
@@ -25,6 +25,18 @@ class FlutterFacebookAppLinks {
     }
   }
 
+  static Future<String> getDeepLink() async {
+    try {
+      var data = await _channel.invokeMethod('getDeepLinkUrl');
+      print('Deferred FB Link: $data');
+      return data ?? '';
+    } catch (e) {
+      debugPrint("Error retrieving deferred deep link: $e");
+
+      return '';
+    }
+  }
+
   static Future<dynamic> consentProvided() {
     return _channel.invokeMethod('consentProvided');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,8 @@ version: 1.2.0+1
 homepage: https://github.com/Mapk26/flutter_facebook_app_links
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
feat: upgrade flutter_facebook_app_links to modern Flutter compatibility

- Update Android Gradle Plugin from 3.3.1 to 8.10.1
- Update compileSdk from 28 to 35, minSdk from 16 to 23
- Update Facebook SDK from 12.3.0 to 16.3.0
- Upgrade Gradle wrapper from 4.10.2 to 8.4
- Migrate from deprecated PluginRegistry.Registrar to Flutter V2 embedding
- Add missing getDeepLink() method with getDeepLinkUrl implementation
- Update iOS deployment target from 9.0 to 12.0 and Swift version to 5.0
- Update Flutter SDK constraints to >=2.17.0 <4.0.0 and Flutter >=3.0.0
- Replace deprecated jcenter() with mavenCentral()
- Add namespace declarations for AGP 8.x compatibility